### PR TITLE
Fixed article URL

### DIFF
--- a/varnish_book.rst
+++ b/varnish_book.rst
@@ -2386,7 +2386,7 @@ Timers
            Another use-case for increasing ``connect_timeout`` occurs when virtual machines are involved as they can increase the connection time significantly.
 
 	.. tip::
-	   More information in https://www.varnish-software.com/blog/understanding-timeouts-varnish-cache.
+	   More information in https://info.varnish-software.com/blog/understanding-timeouts-varnish-cache .
 
 Exercise: Tune ``first_byte_timeout``
 -------------------------------------


### PR DESCRIPTION
- Article about Varnish timeouts is no longer at the documented URL.
- Avoid "." being added to the end of the URL, causing an incorrect link.